### PR TITLE
feat: HTML comment syntax option for select options

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,6 +253,45 @@ Windows instructions here
 
 <!-- tabs:end -->
 
+## use select heading comment
+
+- Type: `boolean`
+- Accepts: `true|false`
+- Default: `false`
+
+
+Changes the syntax for the select options from `--` or  `~~` to appending the an HTML comment (`<!-- select-option -->`) to the heading. For example:
+
+```markdown
+<!-- select:start -->
+<!-- select-menu-labels:Operating System -->
+
+#### macOS <!-- select-option -->
+
+macOS instructions here
+
+#### Linux <!-- select-option -->
+
+Linux instructions here
+
+#### Windows <!-- select-option -->
+
+Windows instructions here
+
+<!-- select:end -->
+```
+
+**Configuration**
+
+```javascript
+window.$docsify = {
+  // ...
+  select: {
+    useSelectHeadingComment: false, // default
+  },
+};
+```
+
 ## theme
 
 - Type: `string`

--- a/src/index.js
+++ b/src/index.js
@@ -46,11 +46,18 @@ const regex = {
 	// 0: Match
 	// 1: Option: #### --Label-- OR #### ~~Label~~
 	// 2: Content
-	selectHeadingMarkup: /[\r\n]*(\s*)#{1,6}\s*[~-]{2}\s*(.*[^\s])\s*[~-]{2}[\r\n]+([\s\S]*?)(?=#{1,6}\s*[~-]{2}|<!-+\s+select:\s*?end\s+-+>)/m
+	selectHeadingMarkup: /[\r\n]*(\s*)#{1,6}\s*[~-]{2}\s*(.*[^\s])\s*[~-]{2}[\r\n]+([\s\S]*?)(?=#{1,6}\s*[~-]{2}|<!-+\s+select:\s*?end\s+-+>)/m,
+
+	// Matches select option and content
+	// 0: Match
+	// 1: Option: #### Label <!-- selection-option -->
+	// 2: Content
+	selectHeadingComment: /[\r\n]*(\s*)#{1,6}\s*(.*?)\s*<!-+\s+select-option\s+-+>[\r\n]+([\s\S]*?)(?=#{1,6}\s*[^\r\n]*<!-+\s+select-option\s+-+>|<!-+\s+select:\s*?end\s+-+>)/m
 };
 
 const settings = {
 	sync: false,
+	useSelectHeadingComment: false,
 	detectOperatingSystem: {enabled: false, menuId: 'operating-system'},
 	theme: 'classic'
 };
@@ -403,6 +410,11 @@ if (window) {
 			settings[key] = window.$docsify.select[key];
 		}
 	});
+
+	if (settings.useSelectHeadingComment) {
+		// Swap these around. Kind of dirty doing it this way.
+		regex.selectHeadingMarkup = regex.selectHeadingComment;
+	}
 
 	// Add plugin data
 	window.$docsify.select.version = pkgVersion;


### PR DESCRIPTION
Adds a less obtrusive syntax option so it can degrade gracefully for when viewing on GitHub etc. Hidden behind _useSelectHeadingComment_ setting (still need to document if you want it).

New optional syntax:

```markdown
#### Label <!-- select-option -->

Stuff
```